### PR TITLE
migrates to paradise 2.0.0-M2

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -16,6 +16,8 @@ resolvers += Resolver.sonatypeRepo("snapshots")
 
 addCompilerPlugin("org.scalamacros" % "paradise" % "2.0.0-M2" cross CrossVersion.full)
 
+parallelExecution in Test := false
+
 libraryDependencies in ThisBuild <++= scalaVersion { (sv: String) => Seq(
 	"org.scala-lang" % "scala-compiler" % sv,
 	"org.scala-lang" % "scala-reflect" % sv,

--- a/build.sbt
+++ b/build.sbt
@@ -4,7 +4,7 @@ projectVersion in ThisBuild := ("0.7.1", SNAPSHOT)
 
 organization in ThisBuild := "org.hablapps"
 
-scalaVersion in ThisBuild := "2.10.2"
+scalaVersion in ThisBuild := "2.10.3"
 
 scalacOptions ++= Seq("-feature", "-deprecation", "-language:reflectiveCalls", "-language:experimental.macros")
 
@@ -14,7 +14,7 @@ scalaSource in Test <<= baseDirectory(_ / "src/test")
 
 resolvers += Resolver.sonatypeRepo("snapshots")
 
-addCompilerPlugin("org.scala-lang.plugins" % "macro-paradise" % "2.0.0-SNAPSHOT" cross CrossVersion.full)
+addCompilerPlugin("org.scalamacros" % "paradise" % "2.0.0-M2" cross CrossVersion.full)
 
 libraryDependencies in ThisBuild <++= scalaVersion { (sv: String) => Seq(
 	"org.scala-lang" % "scala-compiler" % sv,

--- a/src/main/scala/org/hablapps/updatable/Macros.scala
+++ b/src/main/scala/org/hablapps/updatable/Macros.scala
@@ -242,7 +242,7 @@ object Macros {
       newObjectTemplate)
 
     lazy val builderAlias =
-      q"@org.hablapps.updatable.IAmEntityCompanion def $className = macro org.hablapps.updatable.Macros.entityToBuilderImpl[$className]"
+      q"@org.hablapps.updatable.IAmEntityCompanion def ${className.toTermName} = macro org.hablapps.updatable.Macros.entityToBuilderImpl[$className]"
 
     val bldImplName =  newTermName(c.fresh("builder"))
 
@@ -318,7 +318,7 @@ object Macros {
       case EXTENDS_JOIN => tq"Join"
       case EXTENDS_ALLOW => tq"Allow"
     })
-    val newBody = q"type This = $className" :: body
+    val newBody = body :+ q"type This = $className"
     val newTemplate = Template(newParents, self, newBody)
 
     val q"$dummy val ${_} = ???" = 


### PR DESCRIPTION
It all went smooth apart from the necessity to upgrade to 2.10.3,
because I currently don't have milestone releases published for 2.10.2,
only 2.10.3 and 2.11.0-M7 (but I can fix that if necessary).

The two minor changes were necessary, because the implementation of
quasiquotes has evolved to be a bit more picky.
